### PR TITLE
Update app.py

### DIFF
--- a/rphm/app.py
+++ b/rphm/app.py
@@ -745,7 +745,7 @@ def do_actions(device, changes, interval):
                    changes[interface][counter]['direction'])
 
             # system uptime
-            send_trap(trap_content, uptime=device['bootupTimestamp'])
+            send_trap(trap_content, uptime=int(device['bootupTimestamp']))
 
 def send_trap(message, uptime='', test=False):
     """ Send an Arista enterprise-specific SNMP trap containing message.
@@ -810,7 +810,7 @@ def send_trap(message, uptime='', test=False):
     generic_trapnum = '6'
     trap_oid = '.'.join([enterprise_oid, generic_trapnum])
 
-    trap_args.append("'"+str(uptime)+"'")
+    trap_args.append(str(uptime))
     trap_args.append(enterprise_oid)
     trap_args.append(trap_oid)
     trap_args.append('s')


### PR DESCRIPTION
I have tested this on two different deployments (vEOS and 7050SX-64) and was confronted with an incorrect SNMP Trap format as opposed to the expected .1.3.6.1.4.1.30065

Where it appears to fail is in the processing of the system uptime values. On one hand it fails due to the presence of the double quotes  "''" (for test traps), on the other hand for system uptimes that are not integer values: ie 999.9 instead of 999

Fixed the issue by making the following changes

1) Modified send_trap function to round-up uptime argument to integer values
            send_trap(trap_content, uptime=int(device['bootupTimestamp']))

instead of:
# system uptime
            send_trap(trap_content, uptime=device['bootupTimestamp'])

2) Modified trap_args for uptime to remove the ""
trap_args.append(str(uptime))

instead of:
trap_args.append("'"+str(uptime)+"'")

I have tested and confirmed that the changes now produce correctly formatted traps on both vEOS and 7050X.